### PR TITLE
Bug/suhaniii/start lab

### DIFF
--- a/Meshery-Adapters/consul-meshery-adapter/index.json
+++ b/Meshery-Adapters/consul-meshery-adapter/index.json
@@ -46,6 +46,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Meshery-Adapters/istio-meshery-adapter/index.json
+++ b/Meshery-Adapters/istio-meshery-adapter/index.json
@@ -58,6 +58,6 @@
   }, 
 
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Meshery-Adapters/kuma-meshery-adapter/index.json
+++ b/Meshery-Adapters/kuma-meshery-adapter/index.json
@@ -44,6 +44,6 @@
   }, 
 
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Meshery-Adapters/linkerd-meshery-adapter/index.json
+++ b/Meshery-Adapters/linkerd-meshery-adapter/index.json
@@ -42,6 +42,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Meshery-Adapters/nsm-meshery-adapter/index.json
+++ b/Meshery-Adapters/nsm-meshery-adapter/index.json
@@ -42,6 +42,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Performance-Testing-With-Meshery/Running Performance Tests/index.json
+++ b/Performance-Testing-With-Meshery/Running Performance Tests/index.json
@@ -50,6 +50,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }

--- a/Performance-Testing-With-Meshery/Traffic Splitting/index.json
+++ b/Performance-Testing-With-Meshery/Traffic Splitting/index.json
@@ -46,6 +46,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube-running"
+    "imageid": "minikube"
   }
 }


### PR DESCRIPTION
**Description**

This PR fixes #
Previously `minikube start` throw following error
```
$ minikube start
* minikube v1.8.1 on Ubuntu 18.04
* Using the none driver based on existing profile
fatal error: runtime: out of memory

runtime stack:
runtime.throw(0x1a84e87, 0x16)
        /usr/local/go/src/runtime/panic.go:774 +0x72
```

Updating backend imageid resolved it

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
