### PR TITLE
istio: use image with pre running kubernetes

### DIFF
--- a/Meshery-Adapters/istio-meshery-adapter/index.json
+++ b/Meshery-Adapters/istio-meshery-adapter/index.json
@@ -58,6 +58,6 @@
   }, 
 
   "backend": {
-    "imageid": "minikube"
+    "imageid": "kubernetes-cluster-running"
   }
 }


### PR DESCRIPTION
**Description**

Use `kubernetes-cluster-running` image instead of `minikube` to start lab with kubernetes pre running.

This PR is related to #22 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->