### PR TITLE
fixedwrong adapter name for Traefik Mesh lab

### DIFF
--- a/Meshery-Adapters/traefik-meshery-adapter/intro.md
+++ b/Meshery-Adapters/traefik-meshery-adapter/intro.md
@@ -1,8 +1,8 @@
 [Meshery](https://meshery.io) is the service mesh manager, offering lifecycle, configuration, and performance management of service meshes and their workloads.
 
-Using the Meshery Adapter for Linkerd, you will:
+Using the Meshery Adapter for Traefik Mesh, you will:
 
-- Deploy Linkerd and a sample application.
+- Deploy Traefik Mesh and a sample application.
 
 - Verify your service mesh against operational best practices.
 


### PR DESCRIPTION
Signed-off-by: Aditya Chaterjee <speak2adi@gmail.com>

**Description**
The introduction part of Traefik Mesh lab had Linkerd written in it.
This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
