### PR TITLE
k8s for all labs

### DIFF
--- a/Meshery-Adapters/consul-meshery-adapter/index.json
+++ b/Meshery-Adapters/consul-meshery-adapter/index.json
@@ -45,6 +45,6 @@
     "uilayout": "terminal-iframe"
   },
   "backend": {
-    "imageid": "minikube"
+    "imageid": "kubernetes-cluster-running:1.18"
   }
 }

--- a/Meshery-Adapters/istio-meshery-adapter/step1.md
+++ b/Meshery-Adapters/istio-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=istio PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=istio PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
 


### PR DESCRIPTION
**Description**

This PR fixes #22 

**Notes for Reviewers**

- Updated backed image for consul labs
- Updated platform=kubernetes for istio only( We are still facing prompt after meshery start, but with k8s as platform we can see working meshery with chosen adapter after quitting the vim mode)


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
