### PR TITLE
changed platform on install instructions on all adapters

### DIFF
--- a/Meshery-Adapters/consul-meshery-adapter/step1.md
+++ b/Meshery-Adapters/consul-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=consul PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=consul PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
 

--- a/Meshery-Adapters/kuma-meshery-adapter/step1.md
+++ b/Meshery-Adapters/kuma-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=kuma PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=kuma PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
 

--- a/Meshery-Adapters/linkerd-meshery-adapter/step1.md
+++ b/Meshery-Adapters/linkerd-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=linkerd PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=linkerd PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
 

--- a/Meshery-Adapters/nsm-meshery-adapter/step1.md
+++ b/Meshery-Adapters/nsm-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=nsm PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=nsm PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
 

--- a/Meshery-Adapters/osm-meshery-adapter/step1.md
+++ b/Meshery-Adapters/osm-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=osm PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=osm PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Open Service Mesh.
 

--- a/Meshery-Adapters/traefik-meshery-adapter/step1.md
+++ b/Meshery-Adapters/traefik-meshery-adapter/step1.md
@@ -8,7 +8,7 @@ Once ready, you can deploy Meshery.
 
 Meshery can be downloaded, installed, and launched with a single command:
 
-`curl -L https://git.io/meshery | ADAPTERS=traefik PLATFORM=docker bash -`{{execute}}
+`curl -L https://git.io/meshery | ADAPTERS=traefik PLATFORM=kubernetes bash -`{{execute}}
 
 **Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Traefik Mesh.
 


### PR DESCRIPTION
Signed-off-by: asubedy <frexpe@pm.me>

**Description**
The Platforms on install instruction for meshery has been changed to `kubernetes` from `docker` 

This PR fixes #52 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
