### PR TITLE
changed instruction for consul adapters

### DIFF
--- a/Meshery-Adapters/consul-meshery-adapter/step2.md
+++ b/Meshery-Adapters/consul-meshery-adapter/step2.md
@@ -1,6 +1,6 @@
 Consul can be manually installed on your Kubernetes cluster as well. Meshery offers a simple alternative way to do so. 
 
-## 1. Select `Consul` from the Management menu
+## 1. Select `Consul` from the Lifecycle menu
 
 ![Meshery adapter for Consul](./assets/consul-adapter.png)
 
@@ -11,7 +11,7 @@ Consul can be manually installed on your Kubernetes cluster as well. Meshery off
 
 ![Install Consul using Meshery](./assets/install-consul.png)
 
-To check if Istio is along with all the pieces that have been deployed, execute the following:
+To check if Consul is along with all the pieces that have been deployed, execute the following:
 
 `kubectl get all -n consul-system`{{execute}}
 

--- a/Meshery-Adapters/consul-meshery-adapter/step3.md
+++ b/Meshery-Adapters/consul-meshery-adapter/step3.md
@@ -13,7 +13,7 @@ You will be notified of successful deployment:
 
 ## Expose your Sample Application
 
-A sidecar injector is used for automating the injection of the Linkerd proxy into your application's pod spec. The Kubernetes admission controller enforces this behavior by sending a webhook request to the sidecar injector every time a pod is to be scheduled.
+A sidecar injector is used for automating the injection of the Consul proxy into your application's pod spec. The Kubernetes admission controller enforces this behavior by sending a webhook request to the sidecar injector every time a pod is to be scheduled.
 
 You have already deployed the sidecar proxy injector when you installed Consul, which should be running in your control plane. To verify, execute this command:
 


### PR DESCRIPTION
Signed-off-by: asubedy <frexpe@pm.me>

**Description**
changed instances where different adapters was mentioned instead of consul.

This PR fixes #55 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
