### PR TITLE
fix: Correct adapter name in lab sessions

### DIFF
--- a/Meshery-Adapters/consul-meshery-adapter/step1.md
+++ b/Meshery-Adapters/consul-meshery-adapter/step1.md
@@ -10,7 +10,7 @@ Meshery can be downloaded, installed, and launched with a single command:
 
 `curl -L https://git.io/meshery | ADAPTERS=consul PLATFORM=kubernetes bash -`{{execute}}
 
-**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
+**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Consul.
 
 Meshery is now available at host:`9081`.
 

--- a/Meshery-Adapters/istio-meshery-adapter/step1.md
+++ b/Meshery-Adapters/istio-meshery-adapter/step1.md
@@ -10,7 +10,7 @@ Meshery can be downloaded, installed, and launched with a single command:
 
 `curl -L https://git.io/meshery | ADAPTERS=istio PLATFORM=kubernetes bash -`{{execute}}
 
-**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
+**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Istio.
 
 Meshery is now available at host:`9081`.
 

--- a/Meshery-Adapters/nsm-meshery-adapter/step1.md
+++ b/Meshery-Adapters/nsm-meshery-adapter/step1.md
@@ -10,7 +10,7 @@ Meshery can be downloaded, installed, and launched with a single command:
 
 `curl -L https://git.io/meshery | ADAPTERS=nsm PLATFORM=kubernetes bash -`{{execute}}
 
-**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for Linkerd.
+**Congratulations!** You have successfully installed Meshery and the Meshery Adapter for NSM.
 
 Meshery is now available at host:`9081`.
 


### PR DESCRIPTION
Signed-off-by: Everly Precia Suresh <77877486+everly-gif@users.noreply.github.com>

**Description**

While going through the tutorial for [Working with Meshery and Istio](https://layer5.io/learn/service-mesh-labs/working-with-meshery-and-istio) using the istio adapter I found a small typo in the lab sessions. This PR addresses it. Instead of saying **Istio**, it says **Linkerd** which should be corrected. 

 Found some other lab sessions had the same issue as well, addressed the same

Let me know if there is anything else needed from my side. 


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
